### PR TITLE
Make the version param optional in deployment request api

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ request = client.catalog.request(
 #<Vra::DeploymentRequest:0x00007fb7340b7438
 ...
 ```
-To request a deployment from a catalog item, you can use the above method with a project ID that has a cloud template version released to the project. 
-The ID of the catalog item from which you are requesting the deployment should be also included, and the version of the released cloud template. 
+To request a deployment from a catalog item, you can use the above method with a project ID that has a cloud template version released to the project.
+
+The ID of the catalog item from which you are requesting the deployment should be also included, and the version of the released cloud template. If the user doesn't specify a version explicitly, the latest version will be fetched automatically and will be used for the request.
+ 
 Additionally, the name of the deployment should be specified and it should be unique.
 The image mapping specifies the OS image for a VM and the flavor mapping specifies the CPU count and RAM of a VM.
 

--- a/lib/vra/catalog_item.rb
+++ b/lib/vra/catalog_item.rb
@@ -73,12 +73,24 @@ module Vra
       data['iconId']
     end
 
+    def versions
+      client
+        .http_get_paginated_array!("/catalog/api/items/#{id}/versions")
+        .map { |v| v['id'] }
+    end
+
     def entitle!(opts = {})
       super(opts.merge(type: 'CatalogItemIdentifier'))
     end
 
-    def self.entitle!(client, id)
-      new(client, id: id).entitle!
+    class << self
+      def entitle!(client, id)
+        new(client, id: id).entitle!
+      end
+
+      def fetch_latest_version(client, id)
+        new(client, data: { 'id' => id }).versions&.first
+      end
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

### Description

<!--- Describe what this change achieves--->
Currently, the version param in the deployment request api is a required argument. This PR is to make that optional. If the user didn't specify the version explicitly, the latest version of the catalog will be fetched and will be used for requesting the deployment. 

### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
