### PR TITLE
Sends Authorization: Bearer header instead of csp-auth-token

### DIFF
--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -88,7 +88,7 @@ module Vra
       headers                   = {}
       headers['Accept']         = 'application/json'
       headers['Content-Type']   = 'application/json'
-      headers['csp-auth-token'] = @access_token.value unless @access_token.value.nil?
+      headers['Authorization']  = 'Bearer ' + @access_token.value unless @access_token.value.nil?
 
       headers
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -57,13 +57,13 @@ describe Vra::Client do
     context 'when access token exists' do
       it 'has an Authorization header' do
         client.access_token = '12345'
-        expect(client.request_headers.key?('csp-auth-token')).to be true
+        expect(client.request_headers.key?('Authorization')).to be true
       end
     end
 
     context 'when access token does not exist' do
       it 'does not have an Authorization header' do
-        expect(client.request_headers.key?('csp-auth-token')).to be false
+        expect(client.request_headers.key?('Authorization')).to be false
       end
     end
   end


### PR DESCRIPTION
... for greater compatibility

Signed-off-by: Oleg Shvartsman <oshvarts@ford.com>

### Description

Sends Authorization: Bearer header instead of csp-auth-token for greater compatibility

### Issues Resolved

Closes #88

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable (N/A as it's a behind-the-scenes change)
