### PR TITLE
Fix command to run test case

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake test
+      - run: bundle exec rake spec


### PR DESCRIPTION
### Description

Fix rake command for executing test cases.
Ref [Rakefile](https://github.com/test-kitchen/vmware-vra-gem/blob/b8136053d190d1be7fb970f8605be94c4a367b8f/Rakefile#L12), `bundle exec rake test` is not a valid command because this rake gets aborted

### Issues Resolved

- https://github.com/test-kitchen/vmware-vra-gem/runs/5456424712?check_suite_focus=true

### Check List

- [x] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
