### PR TITLE
Fixed the issue with multi-tenancy

### DIFF
--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -80,7 +80,7 @@ module Vra
       {
         'username': @username,
         'password': @password.value,
-        'tenant': @tenant,
+        'domain': @tenant,
       }
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -136,7 +136,7 @@ describe Vra::Client do
       {
         username: "user@corp.local",
         password: "password",
-        tenant: "tenant",
+        domain: "tenant",
       }.to_json
     end
 


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

# Description

In the previous version of the vRA, the expected key to specify the tenant was `tenant`. It is being updated to `domain` in the vRA 8.x. This PR is to update the argument that handles the domain in the API that generates the access token. 

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
