### PR TITLE
Use regular vs admin catalog endpoint to fetch catalog items

### DIFF
--- a/lib/vra/catalog.rb
+++ b/lib/vra/catalog.rb
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 module Vra
   class Catalog
@@ -52,7 +51,7 @@ module Vra
     def fetch_catalog_items(catalog_name)
       fetch_resources(
         Vra::CatalogItem,
-        "/catalog/api/admin/items",
+        "/catalog/api/items",
         "search=#{catalog_name}"
       )
     end

--- a/lib/vra/catalog_item.rb
+++ b/lib/vra/catalog_item.rb
@@ -23,7 +23,7 @@ require "vra/catalog"
 module Vra
   # Class that represents the Catalog Item
   class CatalogItem < Vra::CatalogBase
-    INDEX_URL = "/catalog/api/admin/items"
+    INDEX_URL = "/catalog/api/items"
 
     attr_reader :project_id
 
@@ -40,7 +40,7 @@ module Vra
     end
 
     def fetch_catalog_item
-      @data = client.get_parsed("/catalog/api/admin/items/#{id}")
+      @data = client.get_parsed("/catalog/api/items/#{id}")
     rescue Vra::Exception::HTTPNotFound
       raise Vra::Exception::NotFound, "catalog ID #{id} does not exist"
     end

--- a/spec/catalog_item_spec.rb
+++ b/spec/catalog_item_spec.rb
@@ -69,7 +69,7 @@ describe Vra::CatalogItem do
       let(:response) { double("response", code: 200, body: catalog_item_payload.to_json) }
 
       it "calls http_get against the catalog_service" do
-        expect(client).to receive(:http_get).with("/catalog/api/admin/items/catalog-12345").and_return(response)
+        expect(client).to receive(:http_get).with("/catalog/api/items/catalog-12345").and_return(response)
         Vra::CatalogItem.new(client, id: "catalog-12345")
       end
     end
@@ -78,7 +78,7 @@ describe Vra::CatalogItem do
       it "raises an exception" do
         allow(client)
           .to receive(:http_get)
-          .with("/catalog/api/admin/items/catalog-12345")
+          .with("/catalog/api/items/catalog-12345")
           .and_raise(Vra::Exception::HTTPNotFound)
 
         expect { Vra::CatalogItem.new(client, id: "catalog-12345") }
@@ -91,7 +91,7 @@ describe Vra::CatalogItem do
   describe "#entitle!" do
     it "should entitle the catalog item" do
       allow(client).to receive(:authorized?).and_return(true)
-      stub_request(:get, client.full_url("/catalog/api/admin/items/123456"))
+      stub_request(:get, client.full_url("/catalog/api/items/123456"))
         .to_return(status: 200, body: catalog_item_payload.to_json, headers: {})
 
       response = double("response", body: '{"message": "success"}', success?: true)

--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -44,7 +44,7 @@ describe Vra::Catalog do
   describe "#all_items" do
     it "calls the catalogItems endpoint" do
       expect(client).to receive(:http_get_paginated_array!)
-        .with("/catalog/api/admin/items", nil)
+        .with("/catalog/api/items", nil)
         .and_return([catalog_item])
 
       client.catalog.all_items
@@ -52,7 +52,7 @@ describe Vra::Catalog do
 
     it "returns a Vra::CatalogItem object" do
       allow(client).to receive(:http_get_paginated_array!)
-        .with("/catalog/api/admin/items", nil)
+        .with("/catalog/api/items", nil)
         .and_return([catalog_item])
 
       items = client.catalog.all_items
@@ -154,7 +154,7 @@ describe Vra::Catalog do
 
     it "returns the catalogs by name" do
       expect(client).to receive(:http_get_paginated_array!)
-        .with("/catalog/api/admin/items", "search=centos")
+        .with("/catalog/api/items", "search=centos")
         .and_return([catalog_item])
 
       cat = client.catalog.fetch_catalog_items("centos").first


### PR DESCRIPTION
### Description

It uses regular /api/items catalog endpoint rather than the /api/admin/items endpoint to avoid requirement of using this gem as an account having full VRA admin.  Using regular endpoint, user can operate with their entitled catalog items.

### Issues Resolved

Closes #93 

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable (N/A as behind the scenes change)