### PR TITLE
Updated the tenant attribute to domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ require 'vra'
 => true
 ```
 
-Then, set up your client object. You will need to know your tenant ID from your vRA administrator.
+Then, set up your client object. You will need to know your domain from your vRA administrator.
 
 ```shell
-client = Vra::Client.new(username: 'devmgr@corp.local', password: 'mypassword', tenant: 'mytenant', base_url: 'https://vra.corp.local', verify_ssl: true)
+client = Vra::Client.new(username: 'devmgr@corp.local', password: 'mypassword', domain: 'domain.corp.local', base_url: 'https://vra.corp.local', verify_ssl: true)
 => #<Vra::Client:0x000000034c0df8 ... >
 ```
 
@@ -234,7 +234,7 @@ deployment.requests
 vRA paginates API requests where lists of items are returned.  By default, this gem will ask vRA to provide items in groups of 20.  However, as reported in [Issue 10](https://github.com/chef-partners/vmware-vra-gem/issues/10), it appears vRA may have a pagination bug.  You can change the default page size from 20 to a value of your choice by passing in a `page_size` option when setting up the client:
 
 ```ruby
-vra = Vra::Client.new(username: 'devmgr@corp.local', password: 'mypassword', tenant: 'mytenant', base_url: 'https://vra.corp.local', verify_ssl: true, page_size: 100)
+vra = Vra::Client.new(username: 'devmgr@corp.local', password: 'mypassword', domain: 'domain.corp.local', base_url: 'https://vra.corp.local', verify_ssl: true, page_size: 100)
 ```
 
 ... or setting `page_size` on the client object after you've created it:

--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -33,7 +33,8 @@ module Vra
       @base_url      = opts[:base_url]
       @username      = opts[:username]
       @password      = PasswordMasker.new(opts[:password])
-      @tenant        = opts[:tenant]
+      @domain        = fetch_domain(opts)
+
       @verify_ssl    = opts.fetch(:verify_ssl, true)
       @refresh_token = PasswordMasker.new(nil)
       @access_token  = PasswordMasker.new(nil)
@@ -80,7 +81,7 @@ module Vra
       {
         'username': @username,
         'password': @password.value,
-        'domain': @tenant,
+        'domain': @domain
       }
     end
 
@@ -231,7 +232,7 @@ module Vra
 
     def validate_client_options!
       raise ArgumentError, "Username and password are required" if @username.nil? || @password.value.nil?
-      raise ArgumentError, "A tenant is required" if @tenant.nil?
+      raise ArgumentError, "A domain is required" if @domain.nil?
       raise ArgumentError, "A base URL is required" if @base_url.nil?
       raise ArgumentError, "Base URL #{@base_url} is not a valid URI." unless valid_uri?(@base_url)
     end
@@ -241,6 +242,16 @@ module Vra
       uri.is_a?(URI::HTTP)
     rescue URI::InvalidURIError
       false
+    end
+
+    private
+
+    # This is for backward compatibility, if someone still uses tenant key to pass the domain,
+    # it should also work.
+    def fetch_domain(opts)
+      return opts[:tenant] if opts.key?(:tenant) && !opts.key?(:domain)
+
+      opts[:domain]
     end
   end
 end

--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -81,7 +81,7 @@ module Vra
       {
         'username': @username,
         'password': @password.value,
-        'domain': @domain
+        'domain': @domain,
       }
     end
 

--- a/lib/vra/deployment.rb
+++ b/lib/vra/deployment.rb
@@ -71,6 +71,10 @@ module Vra
       status == "CREATE_FAILED"
     end
 
+    def completion_details
+      requests.last.details
+    end
+
     def completed?
       successful? || failed?
     end

--- a/lib/vra/request.rb
+++ b/lib/vra/request.rb
@@ -76,6 +76,10 @@ module Vra
       status == "FAILED"
     end
 
+    def details
+      request_data["details"]
+    end
+
     private
 
     attr_reader :request_data, :client

--- a/spec/catalog_item_spec.rb
+++ b/spec/catalog_item_spec.rb
@@ -24,7 +24,7 @@ describe Vra::CatalogItem do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/catalog_source_spec.rb
+++ b/spec/catalog_source_spec.rb
@@ -23,7 +23,7 @@ describe Vra::CatalogSource do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -24,7 +24,7 @@ describe Vra::Catalog do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/catalog_type_spec.rb
+++ b/spec/catalog_type_spec.rb
@@ -23,7 +23,7 @@ describe Vra::CatalogType do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -26,7 +26,7 @@ describe Vra::Client do
     {
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local",
     }
   end
@@ -136,7 +136,7 @@ describe Vra::Client do
       {
         username: "user@corp.local",
         password: "password",
-        domain: "tenant",
+        domain: "domain",
       }.to_json
     end
 
@@ -414,7 +414,7 @@ describe Vra::Client do
       let(:unverified_client) do
         Vra::Client.new(username: "user@corp.local",
                         password: "password",
-                        tenant: "tenant",
+                        domain: "domain",
                         base_url: "https://vra.corp.local",
                         verify_ssl: false)
       end
@@ -503,7 +503,7 @@ describe Vra::Client do
       let(:client) do
         described_class.new(
           password: "password",
-          tenant: "tenant",
+          domain: "domain",
           base_url: "https://vra.corp.local"
         )
       end
@@ -517,7 +517,7 @@ describe Vra::Client do
       let(:client) do
         described_class.new(
           username: "username",
-          tenant: "tenant",
+          domain: "domain",
           base_url: "https://vra.corp.local"
         )
       end
@@ -527,7 +527,7 @@ describe Vra::Client do
       end
     end
 
-    context "when tenant is missing" do
+    context "when domain is missing" do
       let(:client) do
         described_class.new(
           username: "username",
@@ -546,7 +546,7 @@ describe Vra::Client do
         described_class.new(
           username: "username",
           password: "password",
-          tenant: "tenant"
+          domain: "domain"
         )
       end
 
@@ -560,7 +560,7 @@ describe Vra::Client do
         described_class.new(
           username: "username",
           password: "password",
-          tenant: "tenant",
+          domain: "domain",
           base_url: "something-that-is-not-a-HTTP-URI"
         )
       end

--- a/spec/deployment_request_spec.rb
+++ b/spec/deployment_request_spec.rb
@@ -24,7 +24,7 @@ describe Vra::DeploymentRequest do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/deployment_spec.rb
+++ b/spec/deployment_spec.rb
@@ -24,7 +24,7 @@ describe ::Vra::Deployment do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/deployments_spec.rb
+++ b/spec/deployments_spec.rb
@@ -24,7 +24,7 @@ describe ::Vra::Deployments do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -37,7 +37,7 @@ describe Vra::Request do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -25,7 +25,7 @@ describe Vra::Resource do
     Vra::Client.new(
       username: "user@corp.local",
       password: "password",
-      tenant: "tenant",
+      domain: "domain",
       base_url: "https://vra.corp.local"
     )
   end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description

vRA8 requires the domain attribute set when creating the VM, instead of the older tenant attribute. Today, the kitchen-vra gem passes the domain via the tenant attribute in the kitchen.yml file. This confuses users. This PR is to introduce a domain attribute (mark it required) and deprecate the existing tenant attribute.

The user needs to define the domain rather than the tenant in the kitchen.yml file when using the kitchen-vra plugin on the vRA8 setup.

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
